### PR TITLE
fix: move patch-package to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "buffer": "^6.0.3",
     "events": "^3.3.0",
     "glob": "^10.4.2",
-    "patch-package": "^8.0.0",
     "path": "^0.12.7",
     "stream": "^0.0.3",
     "string_decoder": "^1.3.0",
@@ -43,6 +42,7 @@
     "@bundled-es-modules/memfs": "^4.2.3",
     "@web/dev-server": "^0.3.3",
     "esbuild": "^0.18.10",
-    "npm-run-all": "^4.1.5"
+    "npm-run-all": "^4.1.5",
+    "patch-package": "^8.0.0"
   }
 }


### PR DESCRIPTION
Moves patch-package to dev dependencies.

This partially addresses #1 but that issue has more parts to it.

There is also an issue in the style-dictionary repo in reguards to this. https://github.com/style-dictionary/style-dictionary/issues/1548